### PR TITLE
Use secondary repo for bot pushing PR

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -419,7 +419,7 @@ function benchmarkRuntime(app, config, octokit) {
               owner: config.owner,
               repo: config.repo,
               title: "Updated Weights",
-              head: `${config.bbRepoOwner}:${config.branch}`, // TODO: may need tweaking (provide git hash?)
+              head: `${config.bbRepoOwner}:${config.bbBranch}`,
               base: config.branch,
               body: `Weights have been updated`, // TODO
               maintainer_can_modify: false,

--- a/bench.js
+++ b/bench.js
@@ -426,8 +426,10 @@ function benchmarkRuntime(app, config, octokit) {
 
             })
           } catch (error) {
+            console.log(`Error while trying to create pull request:`);
+            console.log(error);
             extraInfo =
-              "NOTE: Caught exception while trying to create pull request"
+              `NOTE: Caught exception while trying to create pull request: ${error}`
             app.log.fatal({ msg: extraInfo, error })
           }
         }

--- a/bench.js
+++ b/bench.js
@@ -316,7 +316,6 @@ function benchmarkRuntime(app, config, octokit) {
       }
 
       // Append extra flags to the end of the command
-      console.log(`********************** replacing {pallet_folder}, extra: ${extra}`);
       let benchCommand = benchConfig.benchCommand
       if (command == "custom") {
         // extra here should just be raw arguments to add to the command

--- a/bench.js
+++ b/bench.js
@@ -67,7 +67,7 @@ var BenchConfigs = {
 }
 
 const prepareBranch = async function (
-  { contributor, owner, repo, bbRepo, bbRepoOwner, branch, baseBranch, getPushDomain, getBBPushDomain, },
+  { contributor, owner, repo, bbRepo, bbRepoOwner, bbBranch, branch, baseBranch, getPushDomain, getBBPushDomain, },
   { benchContext },
 ) {
   const gitDirectory = path.join(cwd, "git")
@@ -136,6 +136,12 @@ const prepareBranch = async function (
   )
   if (error) return errorResult(stderr)
   */
+
+  var { error, stderr } = benchContext.runTask(
+    `git checkout -b ${bbBranch}`
+  )
+  if (error)
+    return errorResult(`Failed to "git checkout -b" our secondary branch`);
 }
 
 function benchBranch(app, config) {
@@ -389,7 +395,7 @@ function benchmarkRuntime(app, config, octokit) {
               const { url, token } = await config.getBBPushDomain()
               // TODO: a unique branch should be used to avoid conflicts
               var last = benchContext.runTask(
-                `git remote set-url bb_pr_repo ${url}/${config.bbRepoOwner}/${config.bbRepo}.git && git push bb_pr_repo HEAD`,
+                `git remote set-url bb_pr_repo ${url}/${config.bbRepoOwner}/${config.bbRepo}.git && git push bb_pr_repo ${config.bbBranch}`,
                 `Pushing ${outputFile} to ${config.branch}`,
               )
               if (last.error) {

--- a/bench.js
+++ b/bench.js
@@ -191,6 +191,7 @@ var MoonbeamRuntimeBenchmarkConfigs = {
       "--features=runtime-benchmarks,moonbase-runtime-benchmarks",
       "--",
       "benchmark",
+      "pallet",
       "--chain=dev",
       "--steps=1",
       "--repeat=1",

--- a/bench.js
+++ b/bench.js
@@ -411,13 +411,13 @@ function benchmarkRuntime(app, config, octokit) {
           try {
 
             await octokit.pulls.create({
-              owner: config.bbRepoOwner,
-              repo: config.bbRepo,
+              owner: config.owner,
+              repo: config.repo,
               title: "Updated Weights",
               head: `${config.bbRepoOwner}:${config.branch}`, // TODO: may need tweaking (provide git hash?)
               base: config.branch,
               body: `Weights have been updated`, // TODO
-              maintainer_can_modify: true,
+              maintainer_can_modify: false,
 
             })
           } catch (error) {

--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ module.exports = (app) => {
         toolchain = toolchain.trim()
       }
 
-      const initialInfo = `Starting benchmark for branch: ${branch} (vs ${baseBranch})\n\nToolchain: \n${toolchain}\n\n Comment will be updated.`
+      const initialInfo = `Starting benchmark for branch: ${branch} (vs ${baseBranch})\nPR branch will be ${bbBranch}\n\nToolchain: \n${toolchain}\n\n Comment will be updated.`
       let comment_id = undefined
 
       app.log(initialInfo)
@@ -168,12 +168,16 @@ module.exports = (app) => {
       )
       comment_id = issue_comment.data.id
 
+      // generate a unique branch for our PR
+      const bbBranch = `${branch}-benchbot-job-${new Date().getTime()}`;
+
       let config = {
         owner,
         contributor,
         repo,
         bbRepo,
         bbRepoOwner,
+        bbBranch,
         branch,
         baseBranch,
         id: action,

--- a/index.js
+++ b/index.js
@@ -102,13 +102,11 @@ module.exports = (app) => {
     try {
       const installationId = (context.payload.installation || {}).id
       if (!installationId) {
-        /*
         await context.octokit.issues.createComment(
           context.issue({
             body: `Error: Installation id was missing from webhook payload`,
           }),
         )
-        */
         app.log.error("Installation id was missing from webhook payload");
         return
       }
@@ -149,13 +147,11 @@ module.exports = (app) => {
         { silent: false },
       )
       if (toolchainError) {
-        /*
         await context.octokit.issues.createComment(
           context.issue({
             body: "ERROR: Failed to query the currently active Rust toolchain",
           }),
         )
-        */
         app.log.fatal("ERROR: Failed to query the currently active Rust toolchain");
         return
       } else {
@@ -164,17 +160,13 @@ module.exports = (app) => {
 
       const initialInfo = `Starting benchmark for branch: ${branch} (vs ${baseBranch})\n\nToolchain: \n${toolchain}\n\n Comment will be updated.`
       let comment_id = undefined
-      // if (process.env.DEBUG) {
-        app.log(initialInfo)
-      /*
-      } else {
-        const issueComment = context.issue({ body: initialInfo })
-        const issue_comment = await context.octokit.issues.createComment(
-          issueComment,
-        )
-        comment_id = issue_comment.data.id
-      }
-      */
+
+      app.log(initialInfo)
+      const issueComment = context.issue({ body: initialInfo })
+      const issue_comment = await context.octokit.issues.createComment(
+        issueComment,
+      )
+      comment_id = issue_comment.data.id
 
       let config = {
         owner,
@@ -269,22 +261,15 @@ ${bodySuffix}
 ${extraInfo}
 `.trim()
 
-      /*
       await context.octokit.issues.updateComment({
         owner,
         repo,
         comment_id,
         body,
       })
-      */
     } catch (error) {
       console.log(error);
 
-      // TODO: repo (etc) is out of scope here which causes this catch block to error itself
-      /*
-      const repo = "fixme";
-      const owner = "fixme";
-      const pull_number = "fixme";
       app.log.fatal({
         error,
         repo,
@@ -297,7 +282,6 @@ ${extraInfo}
           body: `Exception caught: \`${error.message}\`\n${error.stack}`,
         }),
       )
-      */
     }
   })
 }

--- a/index.js
+++ b/index.js
@@ -158,6 +158,9 @@ module.exports = (app) => {
         toolchain = toolchain.trim()
       }
 
+      // generate a unique branch for our PR
+      const bbBranch = `${branch}-benchbot-job-${new Date().getTime()}`;
+
       const initialInfo = `Starting benchmark for branch: ${branch} (vs ${baseBranch})\nPR branch will be ${bbBranch}\n\nToolchain: \n${toolchain}\n\n Comment will be updated.`
       let comment_id = undefined
 
@@ -167,9 +170,6 @@ module.exports = (app) => {
         issueComment,
       )
       comment_id = issue_comment.data.id
-
-      // generate a unique branch for our PR
-      const bbBranch = `${branch}-benchbot-job-${new Date().getTime()}`;
 
       let config = {
         owner,

--- a/index.js
+++ b/index.js
@@ -102,11 +102,14 @@ module.exports = (app) => {
     try {
       const installationId = (context.payload.installation || {}).id
       if (!installationId) {
+        /*
         await context.octokit.issues.createComment(
           context.issue({
             body: `Error: Installation id was missing from webhook payload`,
           }),
         )
+        */
+        app.log.error("Installation id was missing from webhook payload");
         return
       }
 
@@ -146,11 +149,14 @@ module.exports = (app) => {
         { silent: false },
       )
       if (toolchainError) {
+        /*
         await context.octokit.issues.createComment(
           context.issue({
             body: "ERROR: Failed to query the currently active Rust toolchain",
           }),
         )
+        */
+        app.log.fatal("ERROR: Failed to query the currently active Rust toolchain");
         return
       } else {
         toolchain = toolchain.trim()
@@ -158,8 +164,9 @@ module.exports = (app) => {
 
       const initialInfo = `Starting benchmark for branch: ${branch} (vs ${baseBranch})\n\nToolchain: \n${toolchain}\n\n Comment will be updated.`
       let comment_id = undefined
-      if (process.env.DEBUG) {
+      // if (process.env.DEBUG) {
         app.log(initialInfo)
+      /*
       } else {
         const issueComment = context.issue({ body: initialInfo })
         const issue_comment = await context.octokit.issues.createComment(
@@ -167,6 +174,7 @@ module.exports = (app) => {
         )
         comment_id = issue_comment.data.id
       }
+      */
 
       let config = {
         owner,
@@ -210,12 +218,14 @@ module.exports = (app) => {
         const output = `${report.message}${report.error ? `: ${report.error.toString()}` : ""
           }`
 
+        /*
         await context.octokit.issues.updateComment({
           owner,
           repo,
           comment_id,
           body: `Error running benchmark: **${branch}**\n\n<details><summary>stdout</summary>${output}</details>`,
         })
+        */
 
         return
       }
@@ -259,16 +269,19 @@ ${bodySuffix}
 ${extraInfo}
 `.trim()
 
+      /*
       await context.octokit.issues.updateComment({
         owner,
         repo,
         comment_id,
         body,
       })
+      */
     } catch (error) {
       console.log(error);
 
       // TODO: repo (etc) is out of scope here which causes this catch block to error itself
+      /*
       const repo = "fixme";
       const owner = "fixme";
       const pull_number = "fixme";
@@ -284,6 +297,7 @@ ${extraInfo}
           body: `Exception caught: \`${error.message}\`\n${error.stack}`,
         }),
       )
+      */
     }
   })
 }


### PR DESCRIPTION
This change provides a configurable secondary repo where the bot will push changes to. These changes are then PR'ed against the original PR branch.

This allows for increased security because the bot doesn't need to have direct write access to the primary repo.