### PR TITLE
Add usage output, other clean up

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -213,7 +213,7 @@ var MoonbeamRuntimeBenchmarkConfigs = {
   },
 }
 
-function checkRuntimeBenchmarkCommand(command) {
+function checkPalletBenchmarkCommand(command) {
   let required = [
     "benchmark",
     "--pallet",
@@ -286,8 +286,8 @@ function matchMoonbeamPallet(palletIsh) {
   throw new Error(`Pallet argument not recognized: ${palletIsh}`);
 }
 
-function benchmarkRuntime(app, config, octokit) {
-  app.log("Waiting our turn to run benchmarkRuntime...")
+function benchmarkPallet(app, config, octokit) {
+  app.log("Waiting our turn to run benchmarkPallet...")
 
   return mutex.runExclusive(async function () {
     try {
@@ -303,7 +303,7 @@ function benchmarkRuntime(app, config, octokit) {
       // XXX: testing
       const repo = config.repo.startsWith("moonbeam") ? "moonbeam" : config.repo;
 
-      if (repo == "moonbeam" && config.id == "runtime") {
+      if (repo == "moonbeam" && config.id == "pallet") {
         benchConfig = MoonbeamRuntimeBenchmarkConfigs[command]
       } else {
         return errorResult(
@@ -345,7 +345,7 @@ function benchmarkRuntime(app, config, octokit) {
         benchCommand = benchCommand.replace("{pallet_folder}", palletInfo.dir)
       }
 
-      let missing = checkRuntimeBenchmarkCommand(benchCommand)
+      let missing = checkPalletBenchmarkCommand(benchCommand)
       if (missing.length > 0) {
         return errorResult(`Missing required flags: ${missing.toString()}`)
       }

--- a/bench.js
+++ b/bench.js
@@ -53,19 +53,6 @@ function BenchContext(app, config) {
   }
 }
 
-//::node::import::native::sr25519::transfer_keep_alive::paritydb::small
-
-// const cargoRun = "cargo run --features=runtime-benchmarks --bin moonbeam -- ";
-const cargoRun = "cargo run ";
-
-var BenchConfigs = {
-  ed25519: {
-    title: "Import Benchmark (random transfers, ed25519 signed)",
-    benchCommand:
-      cargoRun + "benchmark --chain dev --execution=native --pallet \"*\" --extrinsic \"*\" --steps 32 --repeat 8 --json --record-proof"
-  },
-}
-
 const prepareBranch = async function (
   { contributor, owner, repo, bbRepo, bbRepoOwner, bbBranch, branch, baseBranch, getPushDomain, getBBPushDomain, },
   { benchContext },
@@ -142,49 +129,6 @@ const prepareBranch = async function (
   )
   if (error)
     return errorResult(`Failed to "git checkout -b" our secondary branch`);
-}
-
-function benchBranch(app, config) {
-  app.log("Waiting our turn to run benchBranch...")
-
-  return mutex.runExclusive(async function () {
-    try {
-      if (config.repo != "moonbeam") {
-        return errorResult("Node benchmarks only available on Moonbeam.")
-      }
-
-      console.log(`config id: ${config.id}`);
-
-      var id = config.id
-      var benchConfig = BenchConfigs[id]
-      if (!benchConfig) {
-        return errorResult(`Bench configuration for "${id}" was not found`)
-      }
-
-      console.log(`bench command: ${benchConfig.benchCommand}`);
-
-      const collector = new libCollector.Collector()
-      var benchContext = new BenchContext(app, config)
-      var { title, benchCommand } = benchConfig
-      app.log(`Started benchmark "${title}."`)
-
-      var error = await prepareBranch(config, { benchContext })
-      if (error) return error
-
-      var { stderr, error, stdout } = benchContext.runTask(
-        benchCommand,
-        `Benching branch ${config.branch}...`,
-      )
-      if (error) return errorResult(stderr)
-
-      await collector.CollectBranchCustomRunner(stdout)
-      let output = await collector.Report()
-
-      return { title, output, extraInfo: "", benchCommand }
-    } catch (error) {
-      return errorResult("Caught exception in benchBranch", error)
-    }
-  })
 }
 
 var MoonbeamRuntimeBenchmarkConfigs = {

--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ module.exports = (app) => {
       // kick off the build/run process...
       // TODO: match usage
       let report
-      if (action == "runtime" {
+      if (action == "runtime") {
         report = await benchmarkRuntime(app, config, context.octokit)
       } else if (action == "rustup") {
         report = await benchRustup(app, config)

--- a/index.js
+++ b/index.js
@@ -199,8 +199,8 @@ module.exports = (app) => {
       // kick off the build/run process...
       // TODO: match usage
       let report
-      if (action == "runtime") {
-        report = await benchmarkRuntime(app, config, context.octokit)
+      if (action == "pallet") {
+        report = await benchmarkPallet(app, config, context.octokit)
       } else if (action == "rustup") {
         report = await benchRustup(app, config)
       } else {


### PR DESCRIPTION
Adds usage output (e.g. `--help`) and improves error handling. I also intend to support runtime-wide benchmarks in this PR.

Current usage:

```
Benchbot usage:

/bench --help
        print this help output
/bench <SUBCOMMAND>
        run the given subcommand

SUBCOMMAND:
    pallet <pallet>
            benchmark a specific pallet and update its weights.rs file
    runtime
            benchmark an entire runtime and update all pallet weights.rs files
            (currently only supports moonbase runtime)
```