### PR TITLE
Verify installation id

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ in the bot's directory.
 - `run {start,stop,restart}`: execute the relevant action for the bot.
 - `run update [ref]`: restart the bot with the branch or PR
   - For branch: `ssh user@remote '/home/benchbot/bench-bot/run update master'`
-  - For PR: `ssh user@remote '/home/benchbot/bench-bot/run update pull/number/head:branch'`
+  - For PR: `ssh user@remote '/home/benchbot/bench-bot/run update pull/number/head:branch'` 
     e.g. `pull/1/head:master`
 
 ### Monitoring Service commands

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Create a `.env` file in the root with the following:
 
 ```
 APP_ID=<App id from Github App Settings>
+INSTALLATION_ID=<Installation id from Github Settings>
 BASE_BRANCH=<the default branch for merging into the PRs, e.g. master>
 CLIENT_ID=<Client ID from Github App Settings>
 CLIENT_SECRET=<Client ID from Github App Settings>
@@ -60,7 +61,7 @@ in the bot's directory.
 - `run {start,stop,restart}`: execute the relevant action for the bot.
 - `run update [ref]`: restart the bot with the branch or PR
   - For branch: `ssh user@remote '/home/benchbot/bench-bot/run update master'`
-  - For PR: `ssh user@remote '/home/benchbot/bench-bot/run update pull/number/head:branch'` 
+  - For PR: `ssh user@remote '/home/benchbot/bench-bot/run update pull/number/head:branch'`
     e.g. `pull/1/head:master`
 
 ### Monitoring Service commands

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ module.exports = (app) => {
 
   const appId = parseInt(process.env.APP_ID)
   assert(appId)
+  const installationId = parseInt(process.env.INSTALLATION_ID);
+  assert(installationId);
 
   const clientId = process.env.CLIENT_ID
   assert(clientId)
@@ -100,8 +102,8 @@ module.exports = (app) => {
     }
 
     try {
-      const installationId = (context.payload.installation || {}).id
-      if (!installationId) {
+      const sourceInstallationId = (context.payload.installation || {}).id
+      if (!sourceInstallationId) {
         await context.octokit.issues.createComment(
           context.issue({
             body: `Error: Installation id was missing from webhook payload`,
@@ -109,6 +111,9 @@ module.exports = (app) => {
         )
         app.log.error("Installation id was missing from webhook payload");
         return
+      } else if (sourceInstallationId != installationId) {
+        console.log(`Warning: ignoring payload from irrelevant installation ${sourceInstallationId}`);
+        return;
       }
 
       const getPushDomain = async function () {


### PR DESCRIPTION
This PR requires `INSTALLATION_ID` to be in the environment and checks this against the `issue_comment` source. This should prevent any issues with the app being public.