### PR TITLE
Remove moonbase-runtime-benchmarks feature

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -194,7 +194,7 @@ var MoonbeamRuntimeBenchmarkConfigs = {
       cargoRun,
       "--release",
       "--bin moonbeam",
-      "--features=runtime-benchmarks,moonbase-runtime-benchmarks",
+      "--features=runtime-benchmarks",
       "--",
       "benchmark",
       "pallet",


### PR DESCRIPTION
Removes `moonbase-runtime-benchmarks` feature flag when building. This was removed recently from the moonbeam repo.